### PR TITLE
Remove php-http/guzzle6-adapter in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,14 +9,14 @@
 
 ### Warning
 
-This bundle is in very early development. However, it is being used in production for at least 3 applications. 
+This bundle is in very early development. However, it is being used in production for at least 3 applications.
 
 ### Installation
 
-Install with Composer: 
+Install with Composer:
 
 ```bash
-composer require happyr/auth0-bundle auth0/auth0-php:@alpha php-http/message php-http/guzzle6-adapter 
+composer require happyr/auth0-bundle auth0/auth0-php:@alpha php-http/message
 ```
 
 Enable the bundle in AppKernel.php
@@ -28,11 +28,11 @@ public function registerBundles()
         // ...
         new \Happyr\Auth0Bundle\HappyrAuth0Bundle(),
     ];
-    
+
     return $bundles;
-}       
+}
 ```
-Add your credentials: 
+Add your credentials:
 
 ```yaml
 // app/config/config.yml
@@ -44,7 +44,7 @@ happyr_auth0:
 ```
 
 
-Configure your application for Singe Sign On (SSO). 
+Configure your application for Singe Sign On (SSO).
 
 ```yaml
 // app/config/security.yml


### PR DESCRIPTION
Hi, 

I got an error when I tried to launch the composer req : 

`composer require happyr/auth0-bundle auth0/auth0-php:@alpha php-http/message php-http/guzzle6-adapter`

```
Using version ^0.5.3 for happyr/auth0-bundle
Using version ^1.8 for php-http/message
Using version ^2.0 for php-http/guzzle6-adapter
./composer.json has been created
Loading composer repositories with package information
Updating dependencies (including require-dev)

Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for happyr/auth0-bundle ^0.5.3 -> satisfiable by happyr/auth0-bundle[0.5.3].
    - happyr/auth0-bundle 0.5.3 requires auth0/auth0-php 6.0.0-alpha.2 -> satisfiable by auth0/auth0-php[6.0.0-alpha.2].
    - auth0/auth0-php 6.0.0-alpha.2 requires php-http/client-implementation ^1.0 -> satisfiable by php-http/guzzle6-adapter[v2.0.0, v2.0.1].
    - php-http/guzzle6-adapter v2.0.0 requires php-http/httplug ^2.0 -> satisfiable by php-http/httplug[v2.0.0].
    - php-http/guzzle6-adapter v2.0.1 requires php-http/httplug ^2.0 -> satisfiable by php-http/httplug[v2.0.0].
    - Conclusion: don't install php-http/httplug v2.0.0


Installation failed, deleting ./composer.json.
```

Because [php-http/guzzle6-adapter](https://packagist.org/packages/php-http/guzzle6-adapter) 2.0 < was recently released and required `php-http/httplug: ^2.0` while [auth0/auth0-php@6.0.0-alpha.2](https://packagist.org/packages/auth0/auth0-php) required `php-http/httplug: ^1.0`.

Another solution is to provide major version of php-http/guzzle6-adapter requirement in your README.md like this : 

`composer require happyr/auth0-bundle auth0/auth0-php:@alpha php-http/message php-http/guzzle6-adapter:^1.0`

Your choice 😄 