### PR TITLE
Support Symfony security-bundle 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr/log": "~1.0",
         "psr/cache": "~1.0",
         "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
-        "symfony/security-bundle": "^3.4 || ^4.3",
+        "symfony/security-bundle": "^3.4 || ^4.3 || ^5.0",
         "symfony/security-core": "^3.4 || ^4.3",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",
         "php-http/httplug": "^1.0 || ^2.0",


### PR DESCRIPTION
In tune with other dependencies tying in with requirements for first-party 5.x Symfony dependencies, following Symfony 5's release, many—including myself—are in need of the `symfony/security-bundle` 5.0.

From what I quickly tested, this seems to build correctly.
(Note: I've been away from pure Symfony for a _very_ long time, only now revisiting for some big projects, so apologies in advance if there are any additional steps for testing that I should've taken.  Any feedback or suggestions for Symfony and Composer package testing methodologies would be appreciated.)