### PR TITLE
Downgrade auth0/auth0-php to an existing version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "auth0/auth0-php": "^8.0.0-BETA2",
+        "auth0/auth0-php": "^8.0.0-BETA1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0",
         "symfony/config": "^5.2",


### PR DESCRIPTION
Downgrading from  `"^8.0.0-BETA2"` to `"^8.0.0-BETA1"`.

There do not seem to be an 8.0.0-BETA2 existing. This was introduced by #47, I believe it is a regression :)